### PR TITLE
Update asset.js

### DIFF
--- a/src/asset.js
+++ b/src/asset.js
@@ -30,6 +30,8 @@ export class Asset {
       throw new Error('Issuer is invalid');
     }
 
+    if(code === 'xlm') code = 'XLM';
+    
     this.code = code;
     this.issuer = issuer;
   }


### PR DESCRIPTION
This would allow only 'XLM' as an asset code for native.  Currently, the constructor allows both 'xlm' and 'XLM' to pass through.  This would probably be a breaking change.